### PR TITLE
Asser _startExpireKeysTimer master fix

### DIFF
--- a/lib/master/Collection.js
+++ b/lib/master/Collection.js
@@ -98,9 +98,8 @@ Collection.prototype._applyConfig = function(config) {
 };
 
 Collection.prototype._startExpireKeysTimer = function() {
-  assert(!this._expireKeysTimer);
-
-  if (!this._expireKeys || !this._count)
+  
+  if (!this._expireKeys || !this._count || this._expireKeysTimer)
     return;
 
   var interval = Math.ceil(this._expireKeys * 1000 / 2);


### PR DESCRIPTION
To avoid crushing muster process I propose to remove assert checking in _startExpireKeysTimer method.